### PR TITLE
Use the new `futarchy-ts` version so that swaps create receiver accounts

### DIFF
--- a/lib/client/rpc/market-clients/ammMarkets.ts
+++ b/lib/client/rpc/market-clients/ammMarkets.ts
@@ -16,7 +16,6 @@ import {
   AmmAccount,
   AmmClient,
   SwapType,
-  getATA,
   getAmmAddr,
 } from "@metadaoproject/futarchy-ts";
 import { Amm as AmmIDLType } from "@metadaoproject/futarchy-ts/dist/types/amm";
@@ -302,31 +301,16 @@ export class FutarchyAmmMarketsRPCClient implements FutarchyAmmMarketsClient {
       outputAmountMinScaled.toNumber(),
       slippage
     );
-    const ix = await this.amm.methods
-      .swap({
+    const tx = await this.ammClient
+      .swapIx(
+        ammMarket.publicKey,
+        ammMarket.baseMint,
+        ammMarket.quoteMint,
         swapType,
-        inputAmount: inputAmountScaled,
-        outputAmountMin: new BN(outputAmountWithSlippage),
-      })
-      .accounts({
-        user: this.transactionSender.owner,
-        amm: ammMarket.publicKey,
-        baseMint: ammMarket.baseMint,
-        quoteMint: ammMarket.quoteMint,
-        userAtaBase: getATA(
-          ammMarket.baseMint,
-          this.transactionSender.owner
-        )[0],
-        userAtaQuote: getATA(
-          ammMarket.quoteMint,
-          this.transactionSender.owner
-        )[0],
-        vaultAtaBase: getATA(ammMarket.baseMint, ammMarket.publicKey)[0],
-        vaultAtaQuote: getATA(ammMarket.quoteMint, ammMarket.publicKey)[0],
-      })
-      .instruction();
-
-    const tx = new Transaction().add(ix);
+        inputAmountScaled,
+        new BN(outputAmountWithSlippage)
+      )
+      .transaction();
 
     return (
       this.transactionSender?.send([tx], this.rpcProvider.connection) ?? []

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metadaoproject/futarchy-sdk",
-  "version": "1.1.0-alpha.5",
+  "version": "1.1.0-alpha.9",
   "main": "dist",
   "scripts": {
     "build": "tsc --project tsconfig.build.json && tscpaths -p tsconfig.json -s ./lib -o ./dist",
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@coral-xyz/anchor": "^0.28.1-beta.2",
-    "@metadaoproject/futarchy-ts": "^1.3.0",
+    "@metadaoproject/futarchy-ts": "^1.3.1",
     "@metaplex-foundation/js": "^0.20.1",
     "@metaplex-foundation/mpl-token-metadata": "^3.2.1",
     "@metaplex-foundation/umi": "^0.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^0.28.1-beta.2
     version: 0.28.1-beta.2
   '@metadaoproject/futarchy-ts':
-    specifier: ^1.3.0
-    version: 1.3.0(fastestsmallesttextencoderdecoder@1.0.22)
+    specifier: ^1.3.1
+    version: 1.3.1(fastestsmallesttextencoderdecoder@1.0.22)
   '@metaplex-foundation/js':
     specifier: ^0.20.1
     version: 0.20.1(arweave@1.15.0)(fastestsmallesttextencoderdecoder@1.0.22)
@@ -708,8 +708,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@metadaoproject/futarchy-ts@1.3.0(fastestsmallesttextencoderdecoder@1.0.22):
-    resolution: {integrity: sha512-HqG7EC8FytdG4jiu/0uFAEdwX6qm74DRsyFlk8mIsw1tnKFM8eSPgTTTiW8SM4mgGK2+QGe8DDqZIJASw5xVGA==}
+  /@metadaoproject/futarchy-ts@1.3.1(fastestsmallesttextencoderdecoder@1.0.22):
+    resolution: {integrity: sha512-ZOdW/PacYyveCsoFTaFXljn/3QT8+Ox+gq6XBG1pL7Qu9JV20ZiNroWXsPVkZvzHkjlvH63VMPsFdf7qynrUNg==}
     dependencies:
       '@coral-xyz/anchor': 0.29.0
       '@solana/spl-token': 0.3.11(@solana/web3.js@1.91.7)(fastestsmallesttextencoderdecoder@1.0.22)
@@ -1696,7 +1696,7 @@ packages:
   /asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
     dependencies:
-      bn.js: 4.11.6
+      bn.js: 4.12.0
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2


### PR DESCRIPTION
I updated the futarchy-ts `swapIx` so that it automagically creates the receiving token account if it doesn't exist. This uses that version.