### PR TITLE
feat: allow owner pubkey to be null for fetching main tokens

### DIFF
--- a/lib/client/client.ts
+++ b/lib/client/client.ts
@@ -49,8 +49,8 @@ export interface FutarchyProposalsClient {
 export interface FutarchyBalancesClient {
   getDaoAggregateMainTokensByMint(
     daoAggregate: DaoAggregate,
-    owner: PublicKey
-  ): Map<string, TokenWithPDA>;
+    owner: PublicKey | null
+  ): Map<string, Pick<TokenWithPDA, "token"> & { pda: PublicKey | null }>;
   fetchMainTokenWalletBalances(
     dao: DaoAggregate,
     ownerWallet: PublicKey

--- a/lib/client/indexer/balances.ts
+++ b/lib/client/indexer/balances.ts
@@ -20,8 +20,8 @@ export class FutarchyIndexerBalancesClient implements FutarchyBalancesClient {
 
   getDaoAggregateMainTokensByMint(
     daoAggregate: DaoAggregate,
-    owner: PublicKey
-  ): Map<string, TokenWithPDA> {
+    owner: PublicKey | null
+  ): Map<string, Pick<TokenWithPDA, "token"> & { pda: PublicKey | null }> {
     return this.rpcBalancesClient.getDaoAggregateMainTokensByMint(
       daoAggregate,
       owner

--- a/lib/client/indexer/balances.ts
+++ b/lib/client/indexer/balances.ts
@@ -18,6 +18,13 @@ export class FutarchyIndexerBalancesClient implements FutarchyBalancesClient {
     this.rpcBalancesClient = rpcBalancesClient;
   }
 
+  /**
+   * The owner can be null even though we are trying to return PDAs. This is because we use this function to populate parts of the UI that
+   * we want to still work when a wallet is disconnected.
+   * @param daoAggregate DaoAggregate
+   * @param owner PublicKey | null
+   * @returns
+   */
   getDaoAggregateMainTokensByMint(
     daoAggregate: DaoAggregate,
     owner: PublicKey | null

--- a/lib/client/rpc/rpcClient.ts
+++ b/lib/client/rpc/rpcClient.ts
@@ -37,10 +37,7 @@ export class FutarchyRPCClient implements FutarchyClient {
       futarchyProtocols,
       transactionSender
     );
-    this.balances = new FutarchyRPCBalancesClient(
-      rpcProvider,
-      futarchyProtocols
-    );
+    this.balances = new FutarchyRPCBalancesClient(rpcProvider);
 
     this.markets = new FutarchyMarketsRPCClient(
       rpcProvider,


### PR DESCRIPTION
Allowing the owner to be null fixes the bug with https://github.com/metaDAOproject/metadao-frontend/issues/68 where the page crashes because we return nothing from this function when the owner is null. BUT we use this to populate the UI and main tokens so without it we won't populate main tokens. Possibly this structure could be revisted where this just returns main tokens and a separate function returns the main tokens with the PDAs, but maybe we could extract all that inside a hook and call it good.
